### PR TITLE
makes delete_key configurable & custom actions context menu on right click

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,12 +10,14 @@ interface TWSettings {
 	tw_bin: string;
 	debug_log: boolean;
 	cache_columns: boolean;
+	delete_key: string;
 }
 
 const DEFAULT_SETTINGS: TWSettings = {
 	tw_bin: 'task',
 	debug_log: false,
 	cache_columns: true,
+	delete_key: "Alt",
 }
 
 class LifeCycleHookMRC extends MarkdownRenderChild {
@@ -161,7 +163,17 @@ class TWSettingTab extends PluginSettingTab {
 					this.plugin.settings.cache_columns = value;
 					await this.plugin.saveSettings();
 				}))
-			
-	
+
+		new Setting(containerEl)
+			.setName('Deletion toggler Key')
+			.setDesc('Key to hold to enable task deletion')
+			.addText(text => text
+				.setPlaceholder('Aalt')
+				.setValue(this.plugin.settings.delete_key)
+				.onChange(async (value) => {
+					this.plugin.settings.delete_key= value;
+					await this.plugin.saveSettings();
+				}));
+
 	}
 }

--- a/src/ui/CustomActionMenu.ts
+++ b/src/ui/CustomActionMenu.ts
@@ -1,0 +1,36 @@
+import { Menu, Notice } from 'obsidian'
+import { TaskEvents } from '../task-handler';
+import type TWPlugin from 'src/main';
+
+function runCommandOnTask(taskUuid: string, command: string, plugin: TWPlugin) {
+	plugin.handler!.modifyTask(taskUuid, command).then(() => {
+			new Notice(`Task ${taskUuid} modified.`);
+			plugin.emitter!.emit(TaskEvents.REFRESH);
+	}).catch(() => {
+			new Notice(`Could not modify task ${taskUuid}!`, 5000);
+	})
+}
+
+export function showActionMenu(taskUuid: string, event: MouseEvent, plugin: TWPlugin) {
+
+	if(!plugin.settings.right_click_context_menu_enabled) {
+		//Ideally the template in the TaskList should'nt add anything to oncontext menu if this feature is disabled
+		//But adding if statement in the TaskList.svelte would made everything much more complicated
+		return
+	}
+
+	const menu = new Menu();
+
+	for (const [_, action] of plugin.settings.right_click_context_menu_actions.entries()) {
+		menu.addItem((item) =>
+			item
+			.setTitle(action.ActionName)
+			.setIcon("documents")
+			.onClick(() => {
+				runCommandOnTask(taskUuid, action.Action, plugin)
+			})
+		);
+	}
+
+	menu.showAtMouseEvent(event);
+}

--- a/src/ui/TaskList.svelte
+++ b/src/ui/TaskList.svelte
@@ -3,6 +3,7 @@
 	import { Report, Task, TaskEvents } from '../task-handler';
 	import { getIcon } from 'obsidian'
 	import { CreateTaskModal, UpdateTaskModal } from '../modals';
+	import { showActionMenu }  from './CustomActionMenu';
 
 	import Status from './col/status.svelte';
 	
@@ -32,7 +33,7 @@
 	$: { formatTimestamp(timestamp) }
 
 	function formatTimestamp(timestamp: number) { formattedAgo = format(timestamp); }
-	
+
 	async function getTasks() {
 		state = 'loading';
 		
@@ -119,7 +120,7 @@
 					</thead>
 					<tbody>
 						{#each reportList.tasks as task, tIndex (task.uuid)}
-							<tr class:row-disabled={task.disabled} class="task-hover">
+							<tr class:row-disabled={task.disabled} class="task-hover" on:contextmenu={ (event) => showActionMenu(task.uuid, event, plugin)} >
 								<Status disabled={task.disabled} status={task.status} altVersion={deleteKeyDown} on:statusChange={(e) => {handleStatusChange(task.uuid, e); task.disabled = true}}/>
 								{#each task.data as data, dIndex}
 									{#if reportList.printedColumns[dIndex].type === 'tags'}
@@ -127,7 +128,7 @@
 									{:else if reportList.printedColumns[dIndex].type === 'urgency'}
 										<Urgency urgency={data}/>
 									{:else}
-										<td on:click={ () => { new UpdateTaskModal(plugin.app, plugin, { uuid: task.uuid }).open() } }>{data}</td>
+										<td on:click={ () => { new UpdateTaskModal(plugin.app, plugin, { uuid: task.uuid }).open() } } >{data}</td>
 									{/if}
 								{/each}
 							</tr>
@@ -137,7 +138,6 @@
 			{/if}
 		{/if}
 	</div>
-
 </div>
 
 <style>

--- a/src/ui/TaskList.svelte
+++ b/src/ui/TaskList.svelte
@@ -24,7 +24,7 @@
 	let state: 'loading' | 'error' | 'ok' = 'loading';
 	let reportList: Omit<Report, 'tasks'> & { tasks: Array<Report['tasks'][number] & {disabled?: true}> };
 	let timestamp: number;
-	let altDown: boolean = false;
+	let deleteKeyDown: boolean = false;
 
 	let refreshButton: HTMLElement;
 	
@@ -52,8 +52,8 @@
 
 	function isChecked(e: Event): boolean { return (e.target as any).checked }
 
-	function onAltDown() { altDown = true; }
-	function onAltUp() { altDown = false; }
+	function onDeleteKeyDown() { deleteKeyDown = true; }
+	function onDeleteKeyUp() { deleteKeyDown = false; }
 
 	async function handleStatusChange(uuid: string, e: Event & { detail: Task['status'] }) {
 		switch (e.detail) {
@@ -81,7 +81,7 @@
 
 </script>
 
-<svelte:window on:keydown={e => e.key === 'Alt' && onAltDown()} on:keyup={e => e.key === 'Alt' && onAltUp()}/>
+<svelte:window on:keydown={e => e.key === plugin.settings.delete_key  && onDeleteKeyDown()} on:keyup={e => e.key === plugin.settings.delete_key && onDeleteKeyUp()}/>
 
 <div>
 
@@ -120,7 +120,7 @@
 					<tbody>
 						{#each reportList.tasks as task, tIndex (task.uuid)}
 							<tr class:row-disabled={task.disabled} class="task-hover">
-								<Status disabled={task.disabled} status={task.status} altVersion={altDown} on:statusChange={(e) => {handleStatusChange(task.uuid, e); task.disabled = true}}/>
+								<Status disabled={task.disabled} status={task.status} altVersion={deleteKeyDown} on:statusChange={(e) => {handleStatusChange(task.uuid, e); task.disabled = true}}/>
 								{#each task.data as data, dIndex}
 									{#if reportList.printedColumns[dIndex].type === 'tags'}
 										<Tags tags={data}/>


### PR DESCRIPTION
## Feature 1: Adds ability to remap delete key toggle
Adds simple option in the config to change the key used to enable task deletion feature.

#### Why this change?
I had an issue with default `Alt` key not working properly when enabling task deletion, so I switched the key to `Shift` but then also decided to play around with the svelte and typescript and make it more configurable.

## Feature 2: Adds custom context menu on right click on task (Disabled by default)

![image](https://github.com/user-attachments/assets/dbe81623-6f38-4000-985a-499530c6155f)

Custom actions can be configured.
![image](https://github.com/user-attachments/assets/5e58b338-e6ad-4167-8f24-bac2fe6ecfd4)

#### Why this change?
I have my own specific `flow` on how I am using taskwarrior and it is great that I am able to modify tasks from the obsidian thanks to `tw-task-wiki`, but the amount of times I had to write `+today` got me thinking that it would be great if I could just click a button and do it quickly. And here we are :)