### PR TITLE
Add tasknote integration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -148,7 +148,7 @@ export default class TWPlugin extends Plugin {
 		let file = this.app.vault.getFileByPath(filePath);
 		if (!file) {
 			try { await this.app.vault.createFolder(folder); } catch {}
-			file = await this.app.vault.create(filePath, `---\ntask_uuid: ${uuid}\n---\n\n`);
+			file = await this.app.vault.create(filePath, `---\ntask_uuid: ${uuid}\n---\n`);
 		}
 		const leaf = this.app.workspace.getLeaf(false);
 		await leaf.openFile(file as TFile);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, PluginSettingTab, Setting, MarkdownRenderChild, Notice } from 'obsidian';
+import { App, Plugin, PluginSettingTab, Setting, MarkdownRenderChild, Notice, TFile } from 'obsidian';
 import TaskList from './ui/TaskList.svelte';
 import { CreateTaskModal } from './modals';
 import { TinyEmitter } from 'tiny-emitter';
@@ -38,6 +38,8 @@ interface TWSettings {
 	right_click_context_menu_actions: RightClickMenuAction[];
 	project_urls_enabled: boolean;
 	project_regex_url_entries: ProjectRegexUrl[];
+	tasknote_enabled: boolean;
+	tasknote_folder: string;
 }
 
 
@@ -49,7 +51,9 @@ const DEFAULT_SETTINGS: TWSettings = {
 	right_click_context_menu_enabled: false,
 	right_click_context_menu_actions: [],
 	project_urls_enabled: false,
-	project_regex_url_entries: []
+	project_regex_url_entries: [],
+	tasknote_enabled: false,
+	tasknote_folder: 'tasknotes',
 }
 
 class LifeCycleHookMRC extends MarkdownRenderChild {
@@ -133,6 +137,19 @@ export default class TWPlugin extends Plugin {
 		this.emitter?.off(TaskEvents.INTERVAL);
 		this.emitter?.off(TaskEvents.REFRESH);
 		this.emitter = undefined;
+	}
+
+	async openTaskNote(uuid: string) {
+		const folder = this.settings.tasknote_folder;
+		const filePath = `${folder}/${uuid}.md`;
+
+		let file = this.app.vault.getFileByPath(filePath);
+		if (!file) {
+			try { await this.app.vault.createFolder(folder); } catch {}
+			file = await this.app.vault.create(filePath, `---\ntask_uuid: ${uuid}\n---\n\n`);
+		}
+		const leaf = this.app.workspace.getLeaf(false);
+		await leaf.openFile(file as TFile);
 	}
 
 	async loadSettings() {
@@ -273,6 +290,36 @@ class TWSettingTab extends PluginSettingTab {
 					this.display();
 				}));
 		
+		new Setting(containerEl)
+			.setName('Enable tasknote integration')
+			.setDesc('Adds an "Note" option when modifying task.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.tasknote_enabled)
+				.onChange(async (value) => {
+					this.plugin.settings.tasknote_enabled = value;
+					await this.plugin.saveSettings();
+					this.display();
+				}));
+
+		if (this.plugin.settings.tasknote_enabled) {
+			const tasknoteDesc = document.createDocumentFragment();
+			tasknoteDesc.append(
+				'Vault-relative folder where task notes are stored. Compatible with ',
+				tasknoteDesc.createEl('a', { text: 'tasknote', href: 'https://github.com/mikebobroski/tasknote' }),
+				' if you configure it with FOLDER=<this folder>, and EXT=.md.',
+			);
+			new Setting(containerEl)
+				.setName('Tasknote folder')
+				.setDesc(tasknoteDesc)
+				.addText(text => text
+					.setPlaceholder('tasknotes')
+					.setValue(this.plugin.settings.tasknote_folder)
+					.onChange(async (value) => {
+						this.plugin.settings.tasknote_folder = value;
+						await this.plugin.saveSettings();
+					}));
+		}
+
 		if(this.plugin.settings.project_urls_enabled) {
 			new Setting(containerEl)
 				.setHeading().setName('Project Regex URIs')

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ interface TWSettings {
 	project_regex_url_entries: ProjectRegexUrl[];
 	tasknote_enabled: boolean;
 	tasknote_folder: string;
+	tasknote_right_click_enabled: boolean;
 }
 
 
@@ -54,6 +55,7 @@ const DEFAULT_SETTINGS: TWSettings = {
 	project_regex_url_entries: [],
 	tasknote_enabled: false,
 	tasknote_folder: 'tasknotes',
+	tasknote_right_click_enabled: false,
 }
 
 class LifeCycleHookMRC extends MarkdownRenderChild {
@@ -316,6 +318,15 @@ class TWSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.tasknote_folder)
 					.onChange(async (value) => {
 						this.plugin.settings.tasknote_folder = value;
+						await this.plugin.saveSettings();
+					}));
+			new Setting(containerEl)
+				.setName('Show in right-click menu')
+				.setDesc('Adds an "Open task note" item to the right-click context menu.')
+				.addToggle(toggle => toggle
+					.setValue(this.plugin.settings.tasknote_right_click_enabled)
+					.onChange(async (value) => {
+						this.plugin.settings.tasknote_right_click_enabled = value;
 						await this.plugin.saveSettings();
 					}));
 		}

--- a/src/ui/CustomActionMenu.ts
+++ b/src/ui/CustomActionMenu.ts
@@ -16,15 +16,26 @@ export function showActionMenu(taskUuid: string, event: MouseEvent, plugin: TWPl
 
 	const menu = new Menu();
 
-	for (const action of plugin.settings.right_click_context_menu_actions.values()) {
+	if (plugin.settings.tasknote_right_click_enabled) {
 		menu.addItem((item) =>
 			item
-			.setTitle(action.ActionName)
-			.setIcon("documents")
-			.onClick(() => {
-				runCommandOnTask(taskUuid, action.Action, plugin)
-			})
+				.setTitle('Open task note')
+				.setIcon('file-text')
+				.onClick(() => plugin.openTaskNote(taskUuid))
 		);
+	}
+
+	if (plugin.settings.right_click_context_menu_enabled) {
+		for (const action of plugin.settings.right_click_context_menu_actions.values()) {
+			menu.addItem((item) =>
+				item
+				.setTitle(action.ActionName)
+				.setIcon("documents")
+				.onClick(() => {
+					runCommandOnTask(taskUuid, action.Action, plugin)
+				})
+			);
+		}
 	}
 
 	menu.showAtMouseEvent(event);

--- a/src/ui/TaskList.svelte
+++ b/src/ui/TaskList.svelte
@@ -127,7 +127,7 @@
 					</thead>
 					<tbody>
 						{#each reportList.tasks as task, tIndex (task.uuid)}
-							<tr class:row-disabled={task.disabled} class="task-hover" on:contextmenu={plugin.settings.right_click_context_menu_enabled ? (event) => showActionMenu(task.uuid, event, plugin): null}>
+							<tr class:row-disabled={task.disabled} class="task-hover" on:contextmenu={(plugin.settings.right_click_context_menu_enabled || plugin.settings.tasknote_right_click_enabled) ? (event) => showActionMenu(task.uuid, event, plugin) : null}>
 								<Status disabled={task.disabled} status={task.status} altVersion={deleteKeyDown} on:statusChange={(e) => {handleStatusChange(task.uuid, e); task.disabled = true}}/>
 								{#each task.data as data, dIndex}
 									<TaskCell handleClick={() => { newUpdateModal(task).open() }}>

--- a/src/ui/TaskModify.svelte
+++ b/src/ui/TaskModify.svelte
@@ -145,6 +145,9 @@
         </div>
         <div style="display: flex; margin-left: auto;">
             <button class="uuid-text action-button" on:click={() => copyToClipboard(task.uuid)}>{shortUuid(task.uuid)}<pre> </pre> {@html getIcon('copy')?.outerHTML} </button>
+            {#if plugin.settings.tasknote_enabled}
+                <button class="action-button" on:click={() => { plugin.openTaskNote(task.uuid); close(); }}>{@html getIcon('file-text')?.outerHTML} Note</button>
+            {/if}
             <button class="action-button" disabled={!readyToModify} on:click={() => modifyTask(getSanitizedInput())}>Modify</button>
         </div>
     </div>


### PR DESCRIPTION
Thanks for maintaining this plugin :)

I used expensive autocomplete (Claude AI) to make some local changes, and offer them up for review. I have tested on my end, but I am not a real programmer so this should not be merged without review. 

Note the logic change in src/ui/CustomActionMenu.ts .

- This PR adds support for per-task notes stored as .md files in the Obsidian vault, compatible with the https://github.com/mikebobroski/tasknote CLI script.

- When enabled, a Note button appears in the modify task modal — clicking it opens (or creates) a note for that task, named by UUID. If the note doesn't exist yet it's created with a task_uuid frontmatter field.                                                                                                                                                                                                      

- Optionally, an Open task note item can also be shown in the right-click context menu.                                                                                                                       

- Both settings are under a new "Enable tasknote integration" toggle in the plugin settings. 